### PR TITLE
Corrected included stylesheet to use bootstrap.css

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,7 @@
 
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
-    <link rel="stylesheet" href="{{ static('css/main.css') }}">
+    <link rel="stylesheet" href="{{ static('css/bootstrap.css') }}">
 </head>
 <body>
     <!--[if lt IE 7]>


### PR DESCRIPTION
Noticed when using this generator that the `base.html` template refers to a `main.css`, but one is not included, and it includes a `bootstrap.css` but it isn't referenced.

This should fix that.
